### PR TITLE
Allow normalizing EOL in TextDiff viewer

### DIFF
--- a/src/components/DiffFileViewer/TextDiff.vue
+++ b/src/components/DiffFileViewer/TextDiff.vue
@@ -21,6 +21,7 @@ const formatter = computed<Formatter | null>(() => {
 
 const ignoreCase = ref<boolean>(false);
 const ignoreWhitespace = ref<boolean>(false);
+const normalizeEOL = ref<boolean>(false);
 const applyFormatter = ref<boolean>(false);
 
 const leftText = computed<string>(() =>
@@ -49,6 +50,10 @@ const differ = ref<Differ | null>(differs.value[0] || null);
 
 function applyDiff(oldText: string, newText: string) {
   let flags: DifferFlag = 0;
+  if (normalizeEOL.value) {
+    oldText = oldText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    newText = newText.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  }
   if (ignoreCase.value) {
     flags |= DifferFlag.IgnoreCase;
   }
@@ -93,7 +98,7 @@ watch(differs, (newDiffers: Differ[]) => {
 
 <template>
   <div class="row mb-2">
-    <div class="col">
+    <div class="col-3">
       <select v-model="differ" class="form-control">
         <option v-for="differ in differs" :value="differ">
           {{ differ.name }}
@@ -148,6 +153,18 @@ watch(differs, (newDiffers: Differ[]) => {
           class="form-check-label"
           :for="`zd-td-ignore-whitespace-${uniqueID}`"
           >Ignore spaces</label
+        >
+      </div>
+      <div class="form-check form-check-inline form-switch">
+        <input
+          class="form-check-input"
+          type="checkbox"
+          role="switch"
+          :id="`zd-td-normalize-eol-${uniqueID}`"
+          v-model="normalizeEOL"
+        />
+        <label class="form-check-label" :for="`zd-td-normalize-eol-${uniqueID}`"
+          >Normalize EOL</label
         >
       </div>
     </div>


### PR DESCRIPTION
| Previous behaviour (EOL not normalized) | New EOL normalization turned on |
|---|---|
| <img width="808" height="517" alt="image" src="https://github.com/user-attachments/assets/b3b09576-8eb0-4c02-a62e-f8c4c030dffe" /> | <img width="775" height="403" alt="image" src="https://github.com/user-attachments/assets/b4a08b96-0a9b-46ef-9136-eee991f5f2b5" /> |




Close #11

cc: @JohnTheFix